### PR TITLE
Create List Play Records endpoint

### DIFF
--- a/api-code/src/endpoints/listPlayRecordsHandler.js
+++ b/api-code/src/endpoints/listPlayRecordsHandler.js
@@ -1,0 +1,34 @@
+const interfaces = require('../helpers/interfaces')
+const HTTP_CODES = require('../helpers/httpCodes')
+const { successResponse, errorResponse } = require('../helpers/responses')
+
+async function handler (event, context) {
+  const { authorizer, console, listObjects } = interfaces.get()
+  await authorizer(event, context)
+  if (event?.authorized?.actions[event.path] !== 'GET') {
+    return errorResponse(HTTP_CODES.clientUnauthorized, 'User not authorized to access this endpoint.')
+  }
+
+  const result = {}
+
+  try {
+    const playRecords = await listObjects({
+      Bucket: 'boardgames-tracking',
+      Prefix: ''
+    })
+    result.playRecords = playRecords?.Contents || []
+
+    console.log(`[List Play Records Handler] Received ${JSON.stringify(playRecords).length} bytes from S3.`)
+  } catch (err) {
+    console.log('[List Play Records Handler] Error', err.message)
+    return errorResponse(HTTP_CODES.serverError, `Unable to list play records: ${err.message} ${err.stack}`)
+  }
+
+  return successResponse(result)
+}
+
+handler.routeName = 'List Play Records'
+handler.routePath = '/playrecords/list'
+handler.routeMethod = 'GET'
+
+module.exports = handler

--- a/api-code/src/helpers/aws/listObjects.js
+++ b/api-code/src/helpers/aws/listObjects.js
@@ -1,0 +1,21 @@
+const { ListObjectsV2Command } = require('@aws-sdk/client-s3')
+const { s3Client } = require('./s3Client')
+
+async function listObjects ({ Bucket, Prefix }) {
+  let success, failure
+  const result = new Promise((resolve, reject) => {
+    success = resolve
+    failure = reject
+  })
+  const listObjectsCommand = new ListObjectsV2Command({ Bucket, Prefix })
+
+  try {
+    const response = await s3Client.send(listObjectsCommand)
+    success(response)
+  } catch (err) {
+    failure(err)
+  }
+  return result
+}
+
+module.exports = listObjects

--- a/api-code/src/helpers/interfaces.js
+++ b/api-code/src/helpers/interfaces.js
@@ -1,12 +1,14 @@
 const authorizer = require('./auth/authorizer')
 const getObject = require('./aws/getObject')
 const putObject = require('./aws/putObject')
+const listObjects = require('./aws/listObjects')
 
 const interfaces = {
   authorizer,
   console,
   getObject,
   putObject,
+  listObjects,
   now: () => new Date()
 }
 const originalInterfaces = Object.assign({}, interfaces)

--- a/api-code/tests/unit/app.test.js
+++ b/api-code/tests/unit/app.test.js
@@ -7,7 +7,7 @@ describe('SAM API App', () => {
   describe('Exported Handlers', () => {
     it('should export expected handler functions', () => {
       const actual = Object.keys(app)
-      const expected = ['createPlayRecordHandler', 'listUsersHandler', 'statusHandler']
+      const expected = ['createPlayRecordHandler', 'listPlayRecordsHandler', 'listUsersHandler', 'statusHandler']
       expect(actual).to.deep.equal(expected)
     })
   })

--- a/api-code/tests/unit/listPlayRecords.test.js
+++ b/api-code/tests/unit/listPlayRecords.test.js
@@ -3,7 +3,7 @@ const logs = require('./helpers/logs')
 const app = require('../../app.js')
 const { modifyInterfaces, resetInterfaces } = require('../../src/helpers/interfaces')
 
-describe.only('List Play Records', () => {
+describe('List Play Records', () => {
   beforeEach(() => {
     logs.capture()
     modifyInterfaces({
@@ -17,9 +17,27 @@ describe.only('List Play Records', () => {
           }
         }
       },
-      putObject () {
-        console.info('Confirm using stub')
-        return false
+      async listObjects () {
+        console.info('Confirm using listObjects stub')
+        return {
+          Contents: [{
+            Key: 'a.json'
+          }, {
+            Key: 'b.json'
+          }, {
+            Key: 'apiKeys.json'
+          }, {
+            Key: 'not-a-json.txt'
+          }]
+        }
+      },
+      async getObject ({ Key }) {
+        console.info(`Confirm using getObject stub for ${Key}`)
+        return JSON.stringify({
+          key: Key,
+          game: 'some game',
+          winner: 'some winner'
+        })
       }
     })
   })
@@ -40,7 +58,12 @@ describe.only('List Play Records', () => {
         'Access-Control-Allow-Origin': '*'
       },
       body: JSON.stringify({
-        playrecords: [{
+        playRecords: [{
+          key: 'a.json',
+          game: 'some game',
+          winner: 'some winner'
+        }, {
+          key: 'b.json',
           game: 'some game',
           winner: 'some winner'
         }]
@@ -51,8 +74,10 @@ describe.only('List Play Records', () => {
     expect(actualBody).to.deep.equal(expectedBody)
     expect(actual).to.deep.equal(expected)
     expect(logs.get()).to.deep.equal([
-      ['info', 'Confirm using stub'],
-      ['log', '[Create Play Record Handler] Successfully stored 49 bytes in boardgames-tracking, 2021/12/2021-12-05T19:19:23.335Z.json']
+      ['info', 'Confirm using listObjects stub'],
+      ['info', 'Confirm using getObject stub for a.json'],
+      ['info', 'Confirm using getObject stub for b.json'],
+      ['log', '[List Play Records Handler] Received 119 bytes from S3.']
     ])
   })
 })

--- a/api-code/tests/unit/listPlayRecords.test.js
+++ b/api-code/tests/unit/listPlayRecords.test.js
@@ -13,7 +13,7 @@ describe.only('List Play Records', () => {
       authorizer (event) {
         event.authorized = {
           actions: {
-            '/createPlayRecord': 'POST'
+            '/playrecords/list': 'GET'
           }
         }
       },
@@ -32,7 +32,7 @@ describe.only('List Play Records', () => {
   it('should return play records from S3', async () => {
     const event = { path: '/playrecords/list', httpMethod: 'GET' }
 
-    const actual = await app.listPlayRecords(event)
+    const actual = await app.listPlayRecordsHandler(event)
     const expected = {
       statusCode: 200,
       headers: {
@@ -46,6 +46,9 @@ describe.only('List Play Records', () => {
         }]
       })
     }
+    const actualBody = JSON.parse(actual.body)
+    const expectedBody = JSON.parse(expected.body)
+    expect(actualBody).to.deep.equal(expectedBody)
     expect(actual).to.deep.equal(expected)
     expect(logs.get()).to.deep.equal([
       ['info', 'Confirm using stub'],

--- a/api-code/tests/unit/listPlayRecords.test.js
+++ b/api-code/tests/unit/listPlayRecords.test.js
@@ -1,0 +1,55 @@
+const { expect } = require('chai')
+const logs = require('./helpers/logs')
+const app = require('../../app.js')
+const { modifyInterfaces, resetInterfaces } = require('../../src/helpers/interfaces')
+
+describe.only('List Play Records', () => {
+  beforeEach(() => {
+    logs.capture()
+    modifyInterfaces({
+      now () {
+        return new Date('2021-12-05T19:19:23.335Z')
+      },
+      authorizer (event) {
+        event.authorized = {
+          actions: {
+            '/createPlayRecord': 'POST'
+          }
+        }
+      },
+      putObject () {
+        console.info('Confirm using stub')
+        return false
+      }
+    })
+  })
+
+  afterEach(() => {
+    resetInterfaces()
+    logs.reset()
+  })
+
+  it('should return play records from S3', async () => {
+    const event = { path: '/playrecords/list', httpMethod: 'GET' }
+
+    const actual = await app.listPlayRecords(event)
+    const expected = {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Credentials': true,
+        'Access-Control-Allow-Origin': '*'
+      },
+      body: JSON.stringify({
+        playrecords: [{
+          game: 'some game',
+          winner: 'some winner'
+        }]
+      })
+    }
+    expect(actual).to.deep.equal(expected)
+    expect(logs.get()).to.deep.equal([
+      ['info', 'Confirm using stub'],
+      ['log', '[Create Play Record Handler] Successfully stored 49 bytes in boardgames-tracking, 2021/12/2021-12-05T19:19:23.335Z.json']
+    ])
+  })
+})

--- a/template.yaml
+++ b/template.yaml
@@ -27,6 +27,21 @@ Resources:
           Properties:
             Path: /createPlayRecord
             Method: POST
+  ListPlayRecordsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: api-code/
+      Handler: app.listPlayRecordsHandler
+      Runtime: nodejs14.x
+      Policies:
+        - S3FullAccessPolicy:
+            BucketName: boardgames-tracking
+      Events:
+        Summary:
+          Type: Api
+          Properties:
+            Path: /playrecords/list
+            Method: GET
   ListUsersFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -68,6 +83,12 @@ Outputs:
   CreatePlayRecordFunctionIamRole:
     Description: Implicit IAM Role created for CreatePlayRecord function
     Value: !GetAtt CreatePlayRecordFunctionRole.Arn
+  ListPlayRecordsFunction:
+    Description: ListPlayRecords Lambda Function ARN
+    Value: !GetAtt ListPlayRecordsFunction.Arn
+  ListPlayRecordsFunctionIamRole:
+    Description: Implicit IAM Role created for ListPlayRecords function
+    Value: !GetAtt ListPlayRecordsFunctionRole.Arn
   ListUsersFunction:
     Description: ListUsers Lambda Function ARN
     Value: !GetAtt ListUsersFunction.Arn


### PR DESCRIPTION
As the title describes... approach:
- List files in S3 bucket
- Filter out non JSON files
- Get files chunks and parse as JSON
- Return data as a list

Out of scope improvements:
- Cache result to JSON file in S3
- Allow dynamic filtering of file keys, e.g. by year, or by date range